### PR TITLE
Ubuntu order  parameters -l{lib}

### DIFF
--- a/examples/Makefile.opengl
+++ b/examples/Makefile.opengl
@@ -6,7 +6,7 @@ LDFLAGS 	+= -framework GLUT -framework OpenGL
 else
 ifeq  (${UNAME}, Linux)
 CPPFLAGS	+= ${shell pkg-config --cflags glu}
-LDFLAGS 	+= ${shell pkg-config --libs glu} -lglut
+LDFLAGS 	+= ${shell pkg-config --libs glu} -lglut -lGL
 else
 ifeq (${shell uname -o}, Msys)
 LDFLAGS 	+= -mwindows -lopengl32 -lfreeglut

--- a/examples/robcmp-simavr-debug/Makefile
+++ b/examples/robcmp-simavr-debug/Makefile
@@ -44,12 +44,12 @@ LDFLAGS := $(filter-out -lsimavr, $(LDFLAGS))
 
 board = ${OBJ}/${target}
 
-${board} : ${LIBDIR}/libsimavr.a
 ${board} : ${OBJ}/${target}.o
 ${board} : ${OBJ}/ssd1306_virt.o
 ${board} : ${OBJ}/ssd1306_glut.o
 ${board} : ${OBJ}/hd44780.o
 ${board} : ${OBJ}/hd44780_glut.o
+	$(CC) $(CFLAGS) $^ ${LIBDIR}/libsimavr.a -o $@ $(LDFLAGS)
 
 ${target}: ${board}
 	@echo $@ done


### PR DESCRIPTION
Change the order of  -l{lib} to the end of compilation line, to gcc work without error.